### PR TITLE
Add Brave as an install target

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,11 +46,13 @@ Darwin)
     TARGET_DIR_CHROMIUM="/Library/Application Support/Chromium/NativeMessagingHosts"
     TARGET_DIR_FIREFOX="/Library/Application Support/Mozilla/NativeMessagingHosts"
     TARGET_DIR_VIVALDI="/Library/Application Support/Vivaldi/NativeMessagingHosts"
+    TARGET_DIR_BRAVE="/Library/Application Support/BraveSoftware/Brave-Browser-Beta/NativeMessagingHosts"
   else
     TARGET_DIR_CHROME="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
     TARGET_DIR_CHROMIUM="$HOME/Library/Application Support/Chromium/NativeMessagingHosts"
     TARGET_DIR_FIREFOX="$HOME/Library/Application Support/Mozilla/NativeMessagingHosts"
     TARGET_DIR_VIVALDI="$HOME/Library/Application Support/Vivaldi/NativeMessagingHosts"
+    TARGET_DIR_BRAVE="$HOME/Library/Application Support/BraveSoftware/Brave-Browser-Beta/NativeMessagingHosts"
   fi
   ;;
 OpenBSD)
@@ -63,6 +65,7 @@ OpenBSD)
   TARGET_DIR_CHROMIUM="$HOME/.config/chromium/NativeMessagingHosts"
   TARGET_DIR_FIREFOX="$HOME/.mozilla/native-messaging-hosts"
   TARGET_DIR_VIVALDI="$HOME/.config/vivaldi/NativeMessagingHosts"
+  TARGET_DIR_BRAVE="$HOME/.config/BraveSoftware/Brave-Browser-Beta/NativeMessagingHosts"
   ;;
 FreeBSD)
   HOST_FILE="$BIN_DIR/browserpass-freebsd64"
@@ -74,6 +77,7 @@ FreeBSD)
   TARGET_DIR_CHROMIUM="$HOME/.config/chromium/NativeMessagingHosts"
   TARGET_DIR_FIREFOX="$HOME/.mozilla/native-messaging-hosts"
   TARGET_DIR_VIVALDI="$HOME/.config/vivaldi/NativeMessagingHosts"
+  TARGET_DIR_BRAVE="$HOME/.config/BraveSoftware/Brave-Browser-Beta/NativeMessagingHosts"
   ;;
 *)
   echo "$OPERATING_SYSTEM is not supported"

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ Linux)
     TARGET_DIR_CHROMIUM="$HOME/.config/chromium/NativeMessagingHosts"
     TARGET_DIR_FIREFOX="$HOME/.mozilla/native-messaging-hosts"
     TARGET_DIR_VIVALDI="$HOME/.config/vivaldi/NativeMessagingHosts"
-    TARGET_DIR_BRAVE="$HOME/.config/BraveSoftware/Brave-Browser-Beta/NativeMessagingHosts"
+    TARGET_DIR_BRAVE="$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
   fi
   ;;
 Darwin)
@@ -46,13 +46,13 @@ Darwin)
     TARGET_DIR_CHROMIUM="/Library/Application Support/Chromium/NativeMessagingHosts"
     TARGET_DIR_FIREFOX="/Library/Application Support/Mozilla/NativeMessagingHosts"
     TARGET_DIR_VIVALDI="/Library/Application Support/Vivaldi/NativeMessagingHosts"
-    TARGET_DIR_BRAVE="/Library/Application Support/BraveSoftware/Brave-Browser-Beta/NativeMessagingHosts"
+    TARGET_DIR_BRAVE="/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts"
   else
     TARGET_DIR_CHROME="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
     TARGET_DIR_CHROMIUM="$HOME/Library/Application Support/Chromium/NativeMessagingHosts"
     TARGET_DIR_FIREFOX="$HOME/Library/Application Support/Mozilla/NativeMessagingHosts"
     TARGET_DIR_VIVALDI="$HOME/Library/Application Support/Vivaldi/NativeMessagingHosts"
-    TARGET_DIR_BRAVE="$HOME/Library/Application Support/BraveSoftware/Brave-Browser-Beta/NativeMessagingHosts"
+    TARGET_DIR_BRAVE="$HOME/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts"
   fi
   ;;
 OpenBSD)
@@ -65,7 +65,7 @@ OpenBSD)
   TARGET_DIR_CHROMIUM="$HOME/.config/chromium/NativeMessagingHosts"
   TARGET_DIR_FIREFOX="$HOME/.mozilla/native-messaging-hosts"
   TARGET_DIR_VIVALDI="$HOME/.config/vivaldi/NativeMessagingHosts"
-  TARGET_DIR_BRAVE="$HOME/.config/BraveSoftware/Brave-Browser-Beta/NativeMessagingHosts"
+  TARGET_DIR_BRAVE="$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
   ;;
 FreeBSD)
   HOST_FILE="$BIN_DIR/browserpass-freebsd64"
@@ -77,7 +77,7 @@ FreeBSD)
   TARGET_DIR_CHROMIUM="$HOME/.config/chromium/NativeMessagingHosts"
   TARGET_DIR_FIREFOX="$HOME/.mozilla/native-messaging-hosts"
   TARGET_DIR_VIVALDI="$HOME/.config/vivaldi/NativeMessagingHosts"
-  TARGET_DIR_BRAVE="$HOME/.config/BraveSoftware/Brave-Browser-Beta/NativeMessagingHosts"
+  TARGET_DIR_BRAVE="$HOME/.config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
   ;;
 *)
   echo "$OPERATING_SYSTEM is not supported"

--- a/install.sh
+++ b/install.sh
@@ -30,11 +30,13 @@ Linux)
     TARGET_DIR_CHROMIUM="/etc/chromium/native-messaging-hosts"
     TARGET_DIR_FIREFOX="/usr/lib/mozilla/native-messaging-hosts"
     TARGET_DIR_VIVALDI="/etc/chromium/native-messaging-hosts"
+    TARGET_DIR_BRAVE="/etc/opt/chrome/native-messaging-hosts"
   else
     TARGET_DIR_CHROME="$HOME/.config/google-chrome/NativeMessagingHosts"
     TARGET_DIR_CHROMIUM="$HOME/.config/chromium/NativeMessagingHosts"
     TARGET_DIR_FIREFOX="$HOME/.mozilla/native-messaging-hosts"
     TARGET_DIR_VIVALDI="$HOME/.config/vivaldi/NativeMessagingHosts"
+    TARGET_DIR_BRAVE="$HOME/.config/BraveSoftware/Brave-Browser-Beta/NativeMessagingHosts"
   fi
   ;;
 Darwin)
@@ -92,7 +94,8 @@ if [ -z "$BROWSER" ]; then
   echo "2) Chromium"
   echo "3) Firefox"
   echo "4) Vivaldi"
-  echo -n "1-4: "
+  echo "5) Brave"
+  echo -n "1-5: "
   read BROWSER
   echo ""
 fi
@@ -115,8 +118,12 @@ case $BROWSER in
   BROWSER_NAME="Vivaldi"
   TARGET_DIR="$TARGET_DIR_VIVALDI"
   ;;
+5|[Bb]rave)
+  BROWSER_NAME="Brave"
+  TARGET_DIR="$TARGET_DIR_BRAVE"
+  ;;
 *)
-  echo "Invalid selection. Please select 1-4 or one of the browser names."
+  echo "Invalid selection. Please select 1-5 or one of the browser names."
   exit 1
   ;;
 esac


### PR DESCRIPTION
The beta version of brave supports chrome extensions now. Therefore, the install script should support brave. This will need to be updated once extension support gets a stable release.
See issue https://github.com/browserpass/browserpass/issues/294.